### PR TITLE
optionally use array in ShowColumns

### DIFF
--- a/src/Chumper/Datatable/Api.php
+++ b/src/Chumper/Datatable/Api.php
@@ -91,9 +91,13 @@ class Api {
     /**
      * @return $this
      */
-    public function showColumns()
+    public function showColumns($cols)
     {
-        foreach (func_get_args() as $property) {
+        if ( ! is_array($cols)) {
+            $cols = func_get_args();
+        }
+
+        foreach ($cols as $property) {
             $this->columns->put($property, new FunctionColumn(function($model) use($property){return $model[$property];}));
         }
         return $this;

--- a/tests/ApiTest.php
+++ b/tests/ApiTest.php
@@ -100,6 +100,10 @@ class ApiTest extends PHPUnit_Framework_TestCase {
         $this->api->showColumns('name', 'email');
 
         $this->assertEquals(array('id','name','email'), $this->api->getOrder());
+
+        $this->api->showColumns(array('foo', 'bar'));
+
+        $this->assertEquals(array('id','name','email', 'foo', 'bar'), $this->api->getOrder());
     }
 
     public function make()


### PR DESCRIPTION
It would be really nice to be able to pass an array to ShowColumns, and it's very easy to do. With this pull request, we can use either of these notations:

```
ShowColumns('foo', 'bar', 'bazz')
```

or 

```
ShowColumns(array('foo', 'bar', 'bazz'))
```

... though in practice, I'll probably write the latter a bit more like this:

```
ShowColumns($myModel->getIndexColumns())
```
