### PR TITLE
BaseEngine : Changed scope of private properties and methods to protecte...

### DIFF
--- a/src/Chumper/Datatable/Engines/BaseEngine.php
+++ b/src/Chumper/Datatable/Engines/BaseEngine.php
@@ -36,7 +36,7 @@ abstract class BaseEngine {
     /**
      * @var
      */
-    private $sEcho;
+    protected  $sEcho;
 
     /**
      * @var \Illuminate\Support\Collection
@@ -46,17 +46,17 @@ abstract class BaseEngine {
     /**
      * @var array
      */
-    private $searchColumns = array();
+    protected  $searchColumns = array();
 
     /**
      * @var array
      */
-    private $showColumns = array();
+    protected $showColumns = array();
 
     /**
      * @var array
      */
-    private $orderColumns = array();
+    protected  $orderColumns = array();
 
     /**
      * @var int
@@ -293,12 +293,12 @@ abstract class BaseEngine {
     {
         return $this->aliasMapping;
     }
-    //-------------PRIVATE FUNCTIONS-------------------
+    //-------------protected functionS-------------------
 
     /**
      * @param $value
      */
-    private function handleiDisplayStart($value)
+    protected function handleiDisplayStart($value)
     {
         //skip
         $this->skip($value);
@@ -307,7 +307,7 @@ abstract class BaseEngine {
     /**
      * @param $value
      */
-    private function handleiDisplayLength($value)
+    protected function handleiDisplayLength($value)
     {
         //limit nicht am query, sondern den ganzen
         //holen und dann dynamisch in der Collection taken und skippen
@@ -317,7 +317,7 @@ abstract class BaseEngine {
     /**
      * @param $value
      */
-    private function handlesEcho($value)
+    protected function handlesEcho($value)
     {
         $this->sEcho = $value;
     }
@@ -325,7 +325,7 @@ abstract class BaseEngine {
     /**
      * @param $value
      */
-    private function handlesSearch($value)
+    protected function handlesSearch($value)
     {
         //handle search on columns sSearch, bRegex
         $this->search($value);
@@ -335,7 +335,7 @@ abstract class BaseEngine {
     /**
      * @param $value
      */
-    private function handleiSortCol_0($value)
+    protected function handleiSortCol_0($value)
     {
         if(Input::get('sSortDir_0') == 'desc')
             $direction = BaseEngine::ORDER_DESC;
@@ -367,7 +367,7 @@ abstract class BaseEngine {
      *
      * @return void
      */
-    private function handleSingleColumnSearch($columnIndex, $searchValue)
+    protected function handleSingleColumnSearch($columnIndex, $searchValue)
     {
         if (!isset($this->searchColumns[$columnIndex])) return;
         if (empty($searchValue)) return;
@@ -402,13 +402,13 @@ abstract class BaseEngine {
      *
      * @return bool
      */
-    private function isParameterForSingleColumnSearch($parameterName)
+    protected function isParameterForSingleColumnSearch($parameterName)
     {
         static $parameterNamePrefix = 'sSearch_';
         return str_contains($parameterName, $parameterNamePrefix);
     }
 
-    private function prepareSearchColumns()
+    protected function prepareSearchColumns()
     {
         if(count($this->searchColumns) == 0 || empty($this->searchColumns))
             $this->searchColumns = $this->showColumns;
@@ -418,7 +418,7 @@ abstract class BaseEngine {
      * @param $column
      * @param $order
      */
-    private function order($column, $order = BaseEngine::ORDER_ASC)
+    protected function order($column, $order = BaseEngine::ORDER_ASC)
     {
         $this->orderColumn = $column;
         $this->orderDirection = $order;
@@ -427,7 +427,7 @@ abstract class BaseEngine {
     /**
      * @param $value
      */
-    private function search($value)
+    protected function search($value)
     {
         $this->search = $value;
     }
@@ -436,7 +436,7 @@ abstract class BaseEngine {
      * @param string $columnName
      * @param mixed $value
      */
-    private function searchOnColumn($columnName, $value)
+    protected function searchOnColumn($columnName, $value)
     {
         $this->columnSearches[$columnName] = $value;
     }
@@ -444,7 +444,7 @@ abstract class BaseEngine {
     /**
      * @param $value
      */
-    private function skip($value)
+    protected function skip($value)
     {
         $this->skip = $value;
     }
@@ -452,7 +452,7 @@ abstract class BaseEngine {
     /**
      * @param $value
      */
-    private function take($value)
+    protected function take($value)
     {
         $this->limit = $value;
     }


### PR DESCRIPTION
Hi,

I needed to extend QueryEngine to modify some implementations. But I connot do this, as some methods and properties are private. 

This pull request just change the scope of those properties and methods to protected.

Hope this can be merged.
