### PR TITLE
Assign the Datatable object to a variable

### DIFF
--- a/src/views/javascript.blade.php
+++ b/src/views/javascript.blade.php
@@ -1,7 +1,7 @@
 <script type="text/javascript">
     jQuery(document).ready(function(){
         // dynamic table
-        jQuery('#{{ $id }}').dataTable({
+        oTable = jQuery('#{{ $id }}').dataTable({
 
         @foreach ($options as $k => $o)
             {{ json_encode($k) }}: {{ json_encode($o) }},


### PR DESCRIPTION
By assigning the datatable object to a variable, we can perform useful actions on the object after creation, such as using fnFilter() to handle search events from custom search inputs. This will give developers more flexibility to customize the way they use the table without affecting existing functionality.
