### PR TITLE
Update BaseEngine.php

### DIFF
--- a/src/Chumper/Datatable/Engines/BaseEngine.php
+++ b/src/Chumper/Datatable/Engines/BaseEngine.php
@@ -397,7 +397,7 @@ abstract class BaseEngine {
     {
         //dd($columnIndex, $searchValue, $this->searchColumns);
         if (!isset($this->searchColumns[$columnIndex])) return;
-        if (empty($searchValue)) return;
+        if (empty($searchValue) && $searchValue !== '0') return;
 
         $columnName = $this->searchColumns[$columnIndex];
         $this->searchOnColumn($columnName, $searchValue);


### PR DESCRIPTION
Issue #92 - bug with '0' column values because of PHP empty($var) function behavior, when we use multi columns filtering.
