### PR TITLE
Add the setOrder function on Datatable::table to predefine sort order

### DIFF
--- a/README.md
+++ b/README.md
@@ -525,6 +525,18 @@ In the datatable view (eg, 'my.datatable.template'):
         });
     @endif
 ```
+
+**setOrder(array $order)**
+
+Defines the order that a datatable will be ordered by on first page load.
+```php
+{{ DataTable::table()
+    ->addColumn('ID', 'First Name', 'Last Name')
+    ->setUrl($ajaxRouteToTableData)
+    ->setOrder(array(2=>'asc', 1=>'asc')) // sort by last name then first name
+    ->render('my.datatable.template') }}
+```
+
 ##Contributors
 
 * [jgoux](https://github.com/jgoux) for helping with searching on number columns in the database

--- a/src/Chumper/Datatable/Table.php
+++ b/src/Chumper/Datatable/Table.php
@@ -164,6 +164,24 @@ class Table {
      * @return $this
      * @throws \Exception
      */
+    public function setOrder($order = array())
+    {
+        $_orders = array();
+        foreach ($order as $number => $sort)
+        {
+            $_orders[] .= '[ ' . $number . ', "' . $sort . '" ]';
+        }
+
+        $_build = '[' . implode(', ', $_orders) . ']';
+
+        $this->callbacks['aaSorting'] = $_build;
+        return $this;
+    }
+
+    /**
+     * @return $this
+     * @throws \Exception
+     */
     public function setCallbacks()
     {
         if(func_num_args() == 2)


### PR DESCRIPTION
This simple function (`setOrder`) allows a table to have a predefined sort order using Datatable:: inside templates.
