### PR TITLE
integrated html5 data-attributes through rowData

### DIFF
--- a/src/Chumper/Datatable/Engines/BaseEngine.php
+++ b/src/Chumper/Datatable/Engines/BaseEngine.php
@@ -38,6 +38,11 @@ abstract class BaseEngine {
     /**
      * @var array
      */
+    protected $rowData = null;
+
+    /**
+     * @var array
+     */
     protected $columnSearches = array();
 
     /**
@@ -288,6 +293,16 @@ abstract class BaseEngine {
         return $this;
     }
 
+    /**
+     * @param $function Set a function for dynamic html5 data attributes
+     * @return $this
+     */
+    public function setRowData($function)
+    {
+        $this->rowData = $function;
+        return $this;
+    }
+
     public function setAliasMapping($value = true)
     {
         $this->aliasMapping = $value;
@@ -320,6 +335,11 @@ abstract class BaseEngine {
     public function getRowId()
     {
         return $this->rowId;
+    }
+
+    public function getRowData()
+    {
+        return $this->rowData;
     }
 
     public function getAliasMapping()

--- a/src/Chumper/Datatable/Engines/CollectionEngine.php
+++ b/src/Chumper/Datatable/Engines/CollectionEngine.php
@@ -262,6 +262,10 @@ class CollectionEngine extends BaseEngine {
             {
                 $entry['DT_RowId'] = call_user_func($self->getRowId(),$row);
             }
+            if(!is_null($self->getRowData()) && is_callable($self->getRowData()))
+            {
+                $entry['DT_RowData'] = call_user_func($self->getRowData(),$row);
+            }
             $i=0;
             foreach ($columns as $col)
             {

--- a/src/Chumper/Datatable/Engines/QueryEngine.php
+++ b/src/Chumper/Datatable/Engines/QueryEngine.php
@@ -206,6 +206,10 @@ class QueryEngine extends BaseEngine {
             {
                 $entry['DT_RowId'] = call_user_func($self->getRowId(),$row);
             }
+            if(!is_null($self->getRowData()) && is_callable($self->getRowData()))
+            {
+                $entry['DT_RowData'] = call_user_func($self->getRowData(),$row);
+            }
             $i = 0;
             foreach ($columns as $col)
             {


### PR DESCRIPTION
At the moment it is only possible to set DT_RowId and DT_RowClass through setRowClass and setRowId.
There is also the option DT_RowData which adds html5 data-attributes to each row.

This option is very useful for passing eg. RowIDs to the client which we can then use in click events.
See http://datatables.net/manual/server-side#Returned-data for reference.

Note: if you're testing this feature, don't only inspect it via firebug for example.
The data-attributes are not visible, they are set via jquery data().
See the data with console.log($("#rowSelector").data());
