### PR TITLE
patch for DateColumn::CUSTOM with Laravel datetime strings

### DIFF
--- a/src/Chumper/Datatable/Columns/DateColumn.php
+++ b/src/Chumper/Datatable/Columns/DateColumn.php
@@ -38,9 +38,14 @@ class DateColumn extends BaseColumn {
     public function run($model)
     {
 
-        if(is_string(is_array($model) ? $model[$this->name]: $model->{$this->name}))
+        if (is_string(is_array($model) ? $model[$this->name] : $model->{$this->name}))
         {
-            return is_array($model) ? $model[$this->name]: $model->{$this->name};
+            if ($this->custom)
+            {
+                return strftime($this->custom, strtotime($model->{$this->name}));
+            }
+
+            return is_array($model) ? $model[$this->name] : $model->{$this->name};
         }
 
         switch($this->format)


### PR DESCRIPTION
Adding a simple patch to allow the use of DateColumn::CUSTOM with Laravel datetime columns in PostgreSQL, which return strings when accessed from the model object. It's really rough and sloppy, but I'm hoping this might start a discussion whereby a cleaner implementation is suggested. I don't mind reworking this to account for all the cases in DateColumn, and to make it a little more robust.
