### PR TITLE
[FIX] test for to add a "and" condition and not a "or"

### DIFF
--- a/src/Chumper/Datatable/Engines/CollectionEngine.php
+++ b/src/Chumper/Datatable/Engines/CollectionEngine.php
@@ -23,6 +23,17 @@ class CollectionEngine extends BaseEngine {
     private $collection;
 
     /**
+     * @var string
+     */
+    const OR_CONDITION = 'OR';
+
+    /**
+     * @var string
+     */
+    const AND_CONDITION = 'AND';
+
+
+    /**
      * @var array Different options
      */
     private $options = array(
@@ -88,9 +99,9 @@ class CollectionEngine extends BaseEngine {
         return $this;
     }
 
-    public function stripOrder($callback = true)
+    public function stripOrder()
     {
-        $this->options['stripOrder'] = $callback;
+        $this->options['stripOrder'] = true;
         return $this;
     }
 
@@ -100,9 +111,10 @@ class CollectionEngine extends BaseEngine {
         return $this;
     }
 
-    public function setOrderStrip($callback = true)
+    public function setOrderStrip()
     {
-        return $this->stripOrder($callback);
+        $this->options['stripOrder'] = true;
+        return $this;
     }
 
     public function setCaseSensitive($value)
@@ -128,7 +140,7 @@ class CollectionEngine extends BaseEngine {
 
     private function doInternalSearch(Collection $columns, array $searchColumns)
     {
-        if(is_null($this->search) or empty($this->search))
+        if((is_null($this->search) || empty($this->search)) && empty($this->fieldSearches))
             return;
 
         $value = $this->search;
@@ -136,24 +148,36 @@ class CollectionEngine extends BaseEngine {
 
         $toSearch = array();
 
+        $searchType = self::AND_CONDITION;
+
         // Map the searchColumns to the real columns
         $ii = 0;
         foreach($columns as $i => $col)
         {
-            if(in_array($columns->get($i)->getName(), $searchColumns))
+            if(in_array($columns->get($i)->getName(), $searchColumns) || in_array($columns->get($i)->getName(), $this->fieldSearches))
             {
-                $toSearch[] = $ii;
+                // map values to columns, where there is no value use the global value
+                if(($field = array_search($columns->get($i)->getName(), $this->fieldSearches)) !== FALSE)
+                {
+                    $toSearch[$ii] = $this->columnSearches[$field];
+                }
+                else
+                {
+                    if($value)
+                        $searchType = self::OR_CONDITION;
+
+                    $toSearch[$ii] = $value;
+                }
             }
             $ii++;
         }
 
         $self = $this;
-        $this->workingCollection = $this->workingCollection->filter(function($row) use ($value, $toSearch, $caseSensitive, $self)
+        $this->workingCollection = $this->workingCollection->filter(function($row) use ($value, $toSearch, $caseSensitive, $self, $searchType)
         {
 
             for($i=0, $stack=array(), $nb=count($row); $i<$nb; $i++)
             {
-                //$toSearch[$i] = value
                 if(!array_key_exists($i, $toSearch))
                     continue;
 
@@ -199,11 +223,18 @@ class CollectionEngine extends BaseEngine {
                 }
             }
 
-            $result = array_diff_key(array_filter($toSearch), $stack);
+            if($searchType == $self::AND_CONDITION)
+            {
+                $result = array_diff_key(array_filter($toSearch), $stack);
 
-            if(empty($result))
-                return true;
-
+                if(empty($result))
+                    return true;
+            }
+            else
+            {
+                if(!empty($stack))
+                    return true;
+            }
         });
     }
 
@@ -223,17 +254,13 @@ class CollectionEngine extends BaseEngine {
             }
             if($stripOrder)
             {
-                if(is_callable($stripOrder)){
-                    return $stripOrder($row, $column);
-                }else{
-                    return strip_tags($row[$column]);
-                }
+                return strip_tags($row[$column]);
             }
             else
             {
                 return $row[$column];
             }
-        }, SORT_NATURAL);
+        });
 
         if($this->orderDirection == BaseEngine::ORDER_DESC)
             $this->workingCollection = $this->workingCollection->reverse();
@@ -253,10 +280,6 @@ class CollectionEngine extends BaseEngine {
             if(!is_null($self->getRowId()) && is_callable($self->getRowId()))
             {
                 $entry['DT_RowId'] = call_user_func($self->getRowId(),$row);
-            }
-            if(!is_null($self->getRowData()) && is_callable($self->getRowData()))
-            {
-                $entry['DT_RowData'] = call_user_func($self->getRowData(),$row);
             }
             $i=0;
             foreach ($columns as $col)


### PR DESCRIPTION
Specific test for to add a "and" condition and not a "or" condition into the collection filter

i take this example on datatable website for the multisearch : 
http://legacy.datatables.net/release-datatables/examples/api/multi_filter.html

But if i enter a multiple value into the textfield, i have a "or" condition result and not a "and".
