### PR TITLE
Remove the groups on the original builder when running the total count.

### DIFF
--- a/src/Chumper/Datatable/Engines/QueryEngine.php
+++ b/src/Chumper/Datatable/Engines/QueryEngine.php
@@ -65,6 +65,10 @@ class QueryEngine extends BaseEngine {
 
     public function totalCount()
     {
+        if ($this->options['distinctCountGroup'])
+        {
+            $this->originalBuilder->groups = null;
+        }
         return $this->originalBuilder->count();
     }
 


### PR DESCRIPTION
Make sure that the totalCount does not use the group by if one or more `groupBy`'s has been set.

This will ensure that the next count() to be run shows the total amount of rows that have been filtered by when a groupBy has been passed to the QueryEngine.

Closes #256