### PR TITLE
Fix for complex options rendering and adds table->hideColumn() for hidden columns (like primary key)

### DIFF
--- a/src/Chumper/Datatable/Table.php
+++ b/src/Chumper/Datatable/Table.php
@@ -460,7 +460,7 @@ class Table {
 
     private function renderOptions($opts = null)
     {
-        $items = $opts ? $opts : $this->options;
+        $items = !is_null($opts) ? $opts : $this->options;
         if($this->isArray($items))
         {
             $items = array_map($this->renderOptions, $items);

--- a/src/views/javascript.blade.php
+++ b/src/views/javascript.blade.php
@@ -1,7 +1,7 @@
 <script type="text/javascript">
     jQuery(document).ready(function(){
         // dynamic table
-        oTable = jQuery('#{{ $id }}').dataTable({{ $optionString }});
+        oTable = jQuery('#{{ $id }}').dataTable({{ $options_string }});
     // custom values are available via $values array
     });
 </script>

--- a/src/views/javascript.blade.php
+++ b/src/views/javascript.blade.php
@@ -1,7 +1,10 @@
 <script type="text/javascript">
     jQuery(document).ready(function(){
         // dynamic table
-        oTable = jQuery('#{{ $id }}').dataTable({{ $options_string }});
+        oTable = jQuery('#{{ $id }}').DataTable({{ $options_string }});
+        @foreach($hidden as $column)
+            oTable.columns({{$column}}).visible(false);
+        @endforeach
     // custom values are available via $values array
     });
 </script>

--- a/src/views/javascript.blade.php
+++ b/src/views/javascript.blade.php
@@ -1,25 +1,7 @@
 <script type="text/javascript">
     jQuery(document).ready(function(){
         // dynamic table
-        oTable = jQuery('#{{ $id }}').dataTable({
-
-        @foreach ($options as $k => $o)
-            {{ json_encode($k) }}: @if(!is_array($o)) @if(preg_match("/function/", $o)) {{ $o }} @else {{ json_encode($o) }}, @endif
-                @else
-                [{
-                    @foreach ($o as $x => $r) 
-                    {{ json_encode($x) }}: @if(is_array($r)) {{ json_encode($r) }}, @elseif(preg_match("/function/", $r)) {{ $r }}, @else {{ json_encode($r) }} @endif
-                    @endforeach
-                }],
-                @endif
-
-        @endforeach
-
-        @foreach ($callbacks as $k => $o)
-            {{ json_encode($k) }}: {{ $o }},
-        @endforeach
-
-        });
+        oTable = jQuery('#{{ $id }}').dataTable({{ $optionString }});
     // custom values are available via $values array
     });
 </script>


### PR DESCRIPTION
This is a really great library - but I ran across two problems with it.

First, complex options rendering wasn't working properly. For instance, when using table tools which required a complicated bit of javascript to specify: eg
```
            oTable = jQuery('#jMlBQOLU').dataTable({
                "sPaginationType": "full_numbers",
                "bProcessing": false,
                "sAjaxSource": "/api/lots",
                "bServerSide": true,
                "dom": 'Tlfrtip',
                "pageLength": 100,
                "lengthChange": true,
                "lengthMenu": [10, 25, 50, 100, 250, 500, 1000],
                "tableTools": {
                    sRowSelect: "os",
                    sSwfPath: "/DataTables-1.10.4/extensions/TableTools/swf/copy_csv_xls_pdf.swf",
                    "aButtons": [
                        {
                            sExtends: "text",
                            sButtonText: "Create",
                            fnClick: function () {
                                document.location.href = document.location.href + '/create';
                            }
                        },
                        {
                            sExtends: "text",
                            sButtonText: "Edit",
                            fnInit: enableButton,
                            fnSelect: enableButton
                        },
                        {
                            sExtends: "text",
                            sButtonText: "Spaces",
                            fnInit: enableButton,
                            fnSelect: enableButton
                        },
                        {
                            sExtends: "text",
                            sButtonText: "Remove",
                            fnInit: enableButton,
                            fnSelect: enableButton
                        }
                    ]
                }
            });
```
I found the tableTools structure not rendering properly for a variety of reasons - among them being a lack of recursion and no way to specify that a value was actually a javascript function name and shouldn't be quoted.  I replace the template based rendering of the structure with a couple private recursive functions in Table itself and pass the fully rendered options string instead.  I noticed that the original code would look for values starting with 'function' to guess if it were a javascript function that shouldn't be quoted.  This is retained, however in my case I already had a javascript function I wanted to use as a callback.  To fix this, I also added support for the javascript: uri scheme.  Thus the above options looks like this in php now.
```
        $options = [
            "sPaginationType"=> "full_numbers",
            "bProcessing"=> false,
            "sAjaxSource"=> "/api/lots",
            "bServerSide"=> true,
            "dom"=> "Tlfrtip",
            "pageLength" => 100,
            "lengthChange"=> true,
            "lengthMenu"=> [ 10, 25, 50, 100, 250, 500, 1000 ],
            "tableTools"=> [
                "sRowSelect"=>"os",
                "sSwfPath"=> "/DataTables-1.10.4/extensions/TableTools/swf/copy_csv_xls_pdf.swf",
                "aButtons"=>[
                    [
                        "sExtends"=> "text",
                        "sButtonText"=> "Create",
                        "fnClick"=> "function() { document.location.href = document.location.href + '/create'; }"
                    ],
                    [
                        "sExtends"=> "text",
                        "sButtonText"=> "Edit",
                        "fnInit"=> "javascript:enableButton",
                        "fnSelect"=> "javascript:enableButton"
                    ],
                    [
                        "sExtends"=> "text",
                        "sButtonText"=> "Spaces",
                        "fnInit"=> "javascript:enableButton",
                        "fnSelect"=> "javascript:enableButton"
                    ],
                    [
                        "sExtends"=> "text",
                        "sButtonText"=> "Remove",
                        "fnInit"=> "function(b){window.enableButton.call(this,b);}",
                        "fnSelect"=> "function(b){window.enableButton.call(this,b);}"
                    ]
                ]
            ]
        ];
```
I left the callbacks on the "Remove" button in the old style - either form does a javascript call on the function with this bound to the table.

The second feature I added was the ability to provide hidden columns.  Generally, I need the primary key of a record to do anything but I don't necessarily want to show it to the user.  So I added hideColumn to Table.  It works a bit like addColumn except the column must already exist.  You can use the index, name or alias.

```
$table = $t = Datatable::table()
            ->noScript()
            ->addColumn('ID', 'Name', 'Address', 'Description')  // these are the column headings to be shown
            ->hideColumn('ID') // columns to hide
            ->setUrl(route('api.lots'))
            ->setOptions($options);
```
