### PR TITLE
Allow getting the query directly out of the QueryEngine.

### DIFF
--- a/src/Chumper/Datatable/Engines/BaseEngine.php
+++ b/src/Chumper/Datatable/Engines/BaseEngine.php
@@ -230,13 +230,21 @@ abstract class BaseEngine {
     }
 
     /**
+     * Used to handle all the inputs directly from an engine, instead of from Datatables.
+     * @see QueryEngine
+     */
+    protected function prepareEngine()
+    {
+        $this->handleInputs();
+        $this->prepareSearchColumns();
+    }
+
+    /**
      * @return \Illuminate\Http\JsonResponse
      */
     public function make()
     {
-        //TODO Handle all inputs
-        $this->handleInputs();
-        $this->prepareSearchColumns();
+        $this->prepareEngine();
 
         $output = array(
             "aaData" => $this->internalMake($this->columns, $this->searchColumns)->toArray(),

--- a/src/Chumper/Datatable/Engines/QueryEngine.php
+++ b/src/Chumper/Datatable/Engines/QueryEngine.php
@@ -41,6 +41,7 @@ class QueryEngine extends BaseEngine {
         'counter'           =>  0,
         'noGroupByOnCount'  =>  false,
         'distinctCountGroup'=>  false,
+        'returnQuery'       =>  false,
     );
 
     function __construct($builder)
@@ -117,6 +118,31 @@ class QueryEngine extends BaseEngine {
         return $this;
     }
 
+    /**
+     * Let internalMake return a QueryBuilder, instead of a collection.
+     *
+     * @param bool $value
+     * @return $this
+     */
+    public function setReturnQuery($value = true)
+    {
+        $this->options['returnQuery'] = $value;
+        return $this;
+    }
+
+    /**
+     * Get a Builder object back from the engine. Don't return a collection.
+     *
+     * @return Query\Builder
+     */
+    public function getQuery()
+    {
+        $this->prepareEngine();
+        $this->setReturnQuery();
+
+        return $this->internalMake($this->columns, $this->searchColumns);
+    }
+
     //--------PRIVATE FUNCTIONS
 
     protected function internalMake(Collection $columns, array $searchColumns = array())
@@ -153,6 +179,10 @@ class QueryEngine extends BaseEngine {
         }
 
         $builder = $this->doInternalOrder($builder, $columns);
+
+        if ($this->options['returnQuery'])
+            return $this->getQuery($builder);
+
         $collection = $this->compile($builder, $columns);
 
         return $collection;
@@ -162,19 +192,27 @@ class QueryEngine extends BaseEngine {
      * @param $builder
      * @return Collection
      */
-    private function getCollection($builder)
+    private function getQuery($builder)
     {
-        if($this->collection == null)
-        {
-            if($this->skip > 0)
-            {
+        // dd($builder->toSql());
+        if ($this->collection == null) {
+            if ($this->skip > 0) {
                 $builder = $builder->skip($this->skip);
             }
-            if($this->limit > 0)
-            {
+            if ($this->limit > 0) {
                 $builder = $builder->take($this->limit);
             }
-            //dd($this->builder->toSql());
+        }
+
+        return $builder;
+    }
+
+    private function getCollection($builder)
+    {
+        $builder = $this->getQuery($builder);
+
+        if ($this->collection == null)
+        {
             $this->collection = $builder->get();
 
             if(is_array($this->collection))
@@ -195,6 +233,7 @@ class QueryEngine extends BaseEngine {
 
         return $builder;
     }
+
     private function buildSearchQuery($builder, $columns)
     {
         $like = $this->options['searchOperator'];


### PR DESCRIPTION
Let internalMake return a QueryBuilder, instead of a collection, allow calling getQuery on the QueryEngine to return the Query\Builder object.