### PR TITLE
Add a new option, queryKeepsLimits defines if the LIMITs should stay

### DIFF
--- a/src/Chumper/Datatable/Engines/QueryEngine.php
+++ b/src/Chumper/Datatable/Engines/QueryEngine.php
@@ -42,6 +42,7 @@ class QueryEngine extends BaseEngine {
         'noGroupByOnCount'  =>  false,
         'distinctCountGroup'=>  false,
         'returnQuery'       =>  false,
+        'queryKeepsLimits'  =>  false,
     );
 
     function __construct($builder)
@@ -132,6 +133,18 @@ class QueryEngine extends BaseEngine {
     }
 
     /**
+     * Change the behaviour of getQueryBuiler for limits
+     *
+     * @param bool $value
+     * @return $this
+     */
+    public function setQueryKeepsLimits($value = true)
+    {
+        $this->options['queryKeepsLimits'] = $value;
+        return $this;
+    }
+
+    /**
      * Get a Builder object back from the engine. Don't return a collection.
      *
      * @return Query\Builder
@@ -182,7 +195,10 @@ class QueryEngine extends BaseEngine {
         $builder = $this->doInternalOrder($builder, $columns);
 
         if ($this->options['returnQuery'])
-            return $this->getQuery($builder);
+            if ($this->options['queryKeepsLimits'])
+                return $this->getQuery($builder);
+            else
+                return $builder;
 
         $collection = $this->compile($builder, $columns);
 
@@ -260,7 +276,7 @@ class QueryEngine extends BaseEngine {
      * @param $builder
      * Modified by sburkett to facilitate individual exact match searching on individual columns (rather than for all columns)
      */
-     
+
     private function buildSingleColumnSearches($builder)
     {
       foreach ($this->columnSearches as $index => $searchValue) {


### PR DESCRIPTION
When exporting a query using the QueryEngine, by default the current behaviour is to run the limit and skip functions on the QueryBuilder.

Sometimes this may be the behaviour that you want.

The default behaviour however should be to get the query without any limit or skips. A new option is introduced to make sure that the limits are the same as they were previously (where the query is the same as what is shown in the datatable).

I will write a wiki article a little later showing a potential new use & implementation of this new functionality, which will allow server-side CSV exports ala TableTools (but for larger data).