### PR TITLE
columnSearches is already defined in BaseEngine.

### DIFF
--- a/src/Chumper/Datatable/Engines/QueryEngine.php
+++ b/src/Chumper/Datatable/Engines/QueryEngine.php
@@ -17,11 +17,6 @@ class QueryEngine extends BaseEngine {
     public $originalBuilder;
 
     /**
-     * @var array single column searches
-     */
-    public $columnSearches = array();
-
-    /**
      * @var Collection the returning collection
      */
     private $resultCollection;


### PR DESCRIPTION
Remove the duplicated definition inside QueryEngine.