### PR TITLE
Removed Config::get from the config file on line 120

### DIFF
--- a/src/config/config.php
+++ b/src/config/config.php
@@ -117,7 +117,7 @@ return array(
           |
         */
         
-        'options_view' => Config::get('chumper.datatable::options')
+        'options_view' => 'chumper.datatable::options',
 
     ),
 


### PR DESCRIPTION
It caused an error:
Class 'Config' not found in ..