### PR TITLE
fix bug for template declaration

### DIFF
--- a/src/config/config.php
+++ b/src/config/config.php
@@ -117,7 +117,7 @@ return array(
           |
         */
         
-        'options_view' => Config::get('chumper.datatable::options')
+        'options_view' => 'chumper.datatable::options'
 
     ),
 


### PR DESCRIPTION
If one of the options passed as array, view won't be found as the template declaration is configured wrong and returns null as a result.