### PR TITLE
Fix null values with MongoDB distinct

### DIFF
--- a/src/Chumper/Datatable/Engines/BaseEngine.php
+++ b/src/Chumper/Datatable/Engines/BaseEngine.php
@@ -218,7 +218,21 @@ abstract class BaseEngine {
             else
             {
                 $this->columns->put($property, new FunctionColumn($property, function($model) use($property){
-                    try{return is_array($model)?$model[$property]:$model->$property;}catch(Exception $e){return null;}    
+                    try
+                    {
+                        if (is_array($model)) 
+                        {
+                            return $model[$property] == null ? $model[0] : $model[$property];
+                        }
+                        else 
+                        {
+                            return $model->$property == null ? $model[0] : $model->$property;
+                        }
+                    }
+                    catch(Exception $e)
+                    {
+                        return null;
+                    }    
                 }));
             }
             $this->showColumns[] = $property;


### PR DESCRIPTION
During the use of MongoDB driver, the *distinct* operation doesn't return the expected string key for the array of results. This kind of behaviour, is exclusively relative to MongoDB because the `$property` doesn't exists, but there is a numeric key for the array instead.
The fix I propose, introduces a nullable check for `$model[$property]` and `$model->$property` and, if this check verifies the nullability, returns the first element of the array of results (*in MongoDB the distinct operation works only on 1 field*).