### PR TITLE
Check if $allColumns[$num] exists first

### DIFF
--- a/src/Chumper/Datatable/Engines/BaseEngine.php
+++ b/src/Chumper/Datatable/Engines/BaseEngine.php
@@ -473,7 +473,7 @@ abstract class BaseEngine {
 
         $allColumns = array_keys($this->columns->all());
         foreach ($sortingCols as $num) {
-            if(in_array($allColumns[$num], $cleanNames)) {
+            if(isset($allColumns[$num]) && in_array($allColumns[$num], $cleanNames)) {
                 $columns[] = array(0 => $num, 1 => $this->orderColumns[array_search($allColumns[$num],$cleanNames)]);
             }
         }


### PR DESCRIPTION
$num is not always in $allColumns, For example if someone manipulates the request:
allColumns => array(6) {
  [0]=>  string(9) "id"
  [1]=>  string(11) "name"
}
sortingColumns => array(1) {
  [0]=>  string(1) "2"
}