### PR TITLE
Making custom values available inside the javascript template

### DIFF
--- a/src/Chumper/Datatable/Table.php
+++ b/src/Chumper/Datatable/Table.php
@@ -357,6 +357,7 @@ class Table {
         return View::make($this->script_view,array(
             'options'   =>  $this->options,
             'callbacks' =>  $this->callbacks,
+            'values'    =>  $this->customValues,
             'id'        =>  $this->idName,
         ));
     }


### PR DESCRIPTION
Need to be able to pass custom values into the javascript template, currently there is a comment in the default javascript template `// custom values are available via $values array` which implies this is possible, however the values are not passed through. The change in this pull request corrects this.

Basically I want to be able to conditionally trigger the dataTable (RowReordering plugin)[https://code.google.com/p/jquery-datatables-row-reordering/wiki/Index] to run, this has to be chained onto the main call to inititalise the dataTable object. For example:

```javascript
<script type="text/javascript">
    jQuery(document).ready(function(){
        // dynamic table
        oTable = jQuery('#{{ $id }}').dataTable({

        @foreach ($options as $k => $o)
        {{ json_encode($k) }}: {{ json_encode($o) }},
        @endforeach

        @foreach ($callbacks as $k => $o)
        {{ json_encode($k) }}: {{ $o }},
        @endforeach

        // custom values are available via $values array
       @if(isset($values['sortable_path']))
            }).rowReordering({ sURL: "{{$values['sortable_path']}}", sRequestType: "GET" });
       @else
            });
       @endif
        });
   });
</script>`