### PR TITLE
Illegal offset type

### DIFF
--- a/src/Chumper/Datatable/Engines/CollectionEngine.php
+++ b/src/Chumper/Datatable/Engines/CollectionEngine.php
@@ -250,15 +250,15 @@ class CollectionEngine extends BaseEngine {
 
             if($self->getAliasMapping())
             {
-                $column = $self->getNameByIndex($column);
+                $column = $self->getNameByIndex($column[0]);
             }
             if($stripOrder)
             {
-                return strip_tags($row[$column]);
+                return strip_tags($row[$column[0]]);
             }
             else
             {
-                return $row[$column];
+                return $row[$column[0]];
             }
         });
 


### PR DESCRIPTION
In line 246, ``$column = $this->orderColumn[0];`` returns an array and thus throws this error. 

Example:
```
Array
(
    [0] => 5
    [1] => expertise
)
```