### PR TITLE
Properly allow mocking Laravel for unit tests.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,9 @@
         "php": ">=5.3.0",
         "illuminate/support": "4.*|~5.0",
         "illuminate/view": "4.*|~5.0",
-        "illuminate/config": "4.*|~5.0"
+        "illuminate/config": "4.*|~5.0",
+        "illuminate/database": "4.*|~5.0",
+        "illuminate/view": "4.*|~5.0"
     },
     "require-dev": {
         "phpunit/phpunit": "3.7.*",

--- a/resources/app/config/app.php
+++ b/resources/app/config/app.php
@@ -1,0 +1,170 @@
+<?php
+return array(
+    /*
+    |--------------------------------------------------------------------------
+    | Application Debug Mode
+    |--------------------------------------------------------------------------
+    |
+    | When your application is in debug mode, detailed error messages with
+    | stack traces will be shown on every error that occurs within your
+    | application. If disabled, a simple generic error page is shown.
+    |
+    */
+    'debug' => false,
+    /*
+    |--------------------------------------------------------------------------
+    | Application URL
+    |--------------------------------------------------------------------------
+    |
+    | This URL is used by the console to properly generate URLs when using
+    | the Artisan command line tool. You should set this to the root of
+    | your application so that it is used when running Artisan tasks.
+    |
+    */
+    'url' => 'http://localhost',
+    /*
+    |--------------------------------------------------------------------------
+    | Application Timezone
+    |--------------------------------------------------------------------------
+    |
+    | Here you may specify the default timezone for your application, which
+    | will be used by the PHP date and date-time functions. We have gone
+    | ahead and set this to a sensible default for you out of the box.
+    |
+    */
+    'timezone' => 'UTC',
+    /*
+    |--------------------------------------------------------------------------
+    | Application Locale Configuration
+    |--------------------------------------------------------------------------
+    |
+    | The application locale determines the default locale that will be used
+    | by the translation service provider. You are free to set this value
+    | to any of the locales which will be supported by the application.
+    |
+    */
+    'locale' => 'en',
+    /*
+    |--------------------------------------------------------------------------
+    | Application Fallback Locale
+    |--------------------------------------------------------------------------
+    |
+    | The fallback locale determines the locale to use when the current one
+    | is not available. You may change the value to correspond to any of
+    | the language folders that are provided through your application.
+    |
+    */
+    'fallback_locale' => 'en',
+    /*
+    |--------------------------------------------------------------------------
+    | Encryption Key
+    |--------------------------------------------------------------------------
+    |
+    | This key is used by the Illuminate encrypter service and should be set
+    | to a random, 32 character string, otherwise these encrypted strings
+    | will not be safe. Please do this before deploying an application!
+    |
+    */
+    'key' => 'YourSecretKey!!!',
+    'cipher' => MCRYPT_RIJNDAEL_128,
+    /*
+    |--------------------------------------------------------------------------
+    | Autoloaded Service Providers
+    |--------------------------------------------------------------------------
+    |
+    | The service providers listed here will be automatically loaded on the
+    | request to your application. Feel free to add your own services to
+    | this array to grant expanded functionality to your applications.
+    |
+    */
+    'providers' => array(
+        'Illuminate\Foundation\Providers\ArtisanServiceProvider',
+        'Illuminate\Auth\AuthServiceProvider',
+        'Illuminate\Cache\CacheServiceProvider',
+        'Illuminate\Session\CommandsServiceProvider',
+        'Illuminate\Foundation\Providers\ConsoleSupportServiceProvider',
+        'Illuminate\Routing\ControllerServiceProvider',
+        'Illuminate\Cookie\CookieServiceProvider',
+        'Illuminate\Database\DatabaseServiceProvider',
+        'Illuminate\Encryption\EncryptionServiceProvider',
+        'Illuminate\Filesystem\FilesystemServiceProvider',
+        'Illuminate\Hashing\HashServiceProvider',
+        'Illuminate\Html\HtmlServiceProvider',
+        'Illuminate\Log\LogServiceProvider',
+        'Illuminate\Mail\MailServiceProvider',
+        'Illuminate\Database\MigrationServiceProvider',
+        'Illuminate\Pagination\PaginationServiceProvider',
+        'Illuminate\Queue\QueueServiceProvider',
+        'Illuminate\Redis\RedisServiceProvider',
+        'Illuminate\Remote\RemoteServiceProvider',
+        'Illuminate\Auth\Reminders\ReminderServiceProvider',
+        'Illuminate\Database\SeedServiceProvider',
+        'Illuminate\Session\SessionServiceProvider',
+        'Illuminate\Translation\TranslationServiceProvider',
+        'Illuminate\Validation\ValidationServiceProvider',
+        'Illuminate\View\ViewServiceProvider',
+        'Illuminate\Workbench\WorkbenchServiceProvider',
+        'Chumper\Datatable\DatatableServiceProvider',
+    ),
+    /*
+    |--------------------------------------------------------------------------
+    | Service Provider Manifest
+    |--------------------------------------------------------------------------
+    |
+    | The service provider manifest is used by Laravel to lazy load service
+    | providers which are not needed for each request, as well to keep a
+    | list of all of the services. Here, you may set its storage spot.
+    |
+    */
+    'manifest' => __DIR__.'/../meta',
+    /*
+    |--------------------------------------------------------------------------
+    | Class Aliases
+    |--------------------------------------------------------------------------
+    |
+    | This array of class aliases will be registered when this application
+    | is started. However, feel free to register as many as you wish as
+    | the aliases are "lazy" loaded so they don't hinder performance.
+    |
+    */
+    'aliases' => array(
+        'App'               => 'Illuminate\Support\Facades\App',
+        'Artisan'           => 'Illuminate\Support\Facades\Artisan',
+        'Auth'              => 'Illuminate\Support\Facades\Auth',
+        'Blade'             => 'Illuminate\Support\Facades\Blade',
+        'Cache'             => 'Illuminate\Support\Facades\Cache',
+        'ClassLoader'       => 'Illuminate\Support\ClassLoader',
+        'Config'            => 'Illuminate\Support\Facades\Config',
+        'Controller'        => 'Illuminate\Routing\Controller',
+        'Cookie'            => 'Illuminate\Support\Facades\Cookie',
+        'Crypt'             => 'Illuminate\Support\Facades\Crypt',
+        'DB'                => 'Illuminate\Support\Facades\DB',
+        'Eloquent'          => 'Illuminate\Database\Eloquent\Model',
+        'Event'             => 'Illuminate\Support\Facades\Event',
+        'File'              => 'Illuminate\Support\Facades\File',
+        'Form'              => 'Illuminate\Support\Facades\Form',
+        'Hash'              => 'Illuminate\Support\Facades\Hash',
+        'HTML'              => 'Illuminate\Support\Facades\HTML',
+        'Input'             => 'Illuminate\Support\Facades\Input',
+        'Lang'              => 'Illuminate\Support\Facades\Lang',
+        'Log'               => 'Illuminate\Support\Facades\Log',
+        'Mail'              => 'Illuminate\Support\Facades\Mail',
+        'Paginator'         => 'Illuminate\Support\Facades\Paginator',
+        'Password'          => 'Illuminate\Support\Facades\Password',
+        'Queue'             => 'Illuminate\Support\Facades\Queue',
+        'Redirect'          => 'Illuminate\Support\Facades\Redirect',
+        'Redis'             => 'Illuminate\Support\Facades\Redis',
+        'Request'           => 'Illuminate\Support\Facades\Request',
+        'Response'          => 'Illuminate\Support\Facades\Response',
+        'Route'             => 'Illuminate\Support\Facades\Route',
+        'Schema'            => 'Illuminate\Support\Facades\Schema',
+        'Seeder'            => 'Illuminate\Database\Seeder',
+        'Session'           => 'Illuminate\Support\Facades\Session',
+        'SoftDeletingTrait' => 'Illuminate\Database\Eloquent\SoftDeletingTrait',
+        'SSH'               => 'Illuminate\Support\Facades\SSH',
+        'Str'               => 'Illuminate\Support\Str',
+        'URL'               => 'Illuminate\Support\Facades\URL',
+        'Validator'         => 'Illuminate\Support\Facades\Validator',
+        'View'              => 'Illuminate\Support\Facades\View',
+    ),
+);

--- a/resources/app/config/view.php
+++ b/resources/app/config/view.php
@@ -1,0 +1,25 @@
+<?php
+return array(
+    /*
+    |--------------------------------------------------------------------------
+    | View Storage Paths
+    |--------------------------------------------------------------------------
+    |
+    | Most templating systems load templates from disk. Here you may specify
+    | an array of paths that should be checked for your views. Of course
+    | the usual Laravel view path has already been registered for you.
+    |
+    */
+    'paths' => array(__DIR__.'/../views'),
+    /*
+    |--------------------------------------------------------------------------
+    | Pagination View
+    |--------------------------------------------------------------------------
+    |
+    | This view will be used to render the pagination link output, and can
+    | be easily customized here to show any view you like. A clean view
+    | compatible with Twitter's Bootstrap is given to you by default.
+    |
+    */
+    'pagination' => 'pagination::slider-3',
+);

--- a/resources/paths.php
+++ b/resources/paths.php
@@ -1,0 +1,47 @@
+<?php
+return array(
+	/*
+	|--------------------------------------------------------------------------
+	| Application Path
+	|--------------------------------------------------------------------------
+	|
+	| Here we just defined the path to the application directory. Most likely
+	| you will never need to change this value as the default setup should
+	| work perfectly fine for the vast majority of all our applications.
+	|
+	*/
+	'app' => __DIR__.'/app',
+	/*
+	|--------------------------------------------------------------------------
+	| Public Path
+	|--------------------------------------------------------------------------
+	|
+	| The public path contains the assets for your web application, such as
+	| your JavaScript and CSS files, and also contains the primary entry
+	| point for web requests into these applications from the outside.
+	|
+	*/
+	'public' => __DIR__.'/public',
+	/*
+	|--------------------------------------------------------------------------
+	| Base Path
+	|--------------------------------------------------------------------------
+	|
+	| The base path is the root of the Laravel installation. Most likely you
+	| will not need to change this value. But, if for some wild reason it
+	| is necessary you will do so here, just proceed with some caution.
+	|
+	*/
+	'base' => __DIR__.'/',
+	/*
+	|--------------------------------------------------------------------------
+	| Storage Path
+	|--------------------------------------------------------------------------
+	|
+	| The storage path is used by Laravel to store cached Blade views, logs
+	| and other pieces of information. You may modify the path here when
+	| you want to change the location of this directory for your apps.
+	|
+	*/
+	'storage' => __DIR__.'/app/storage',
+);

--- a/src/Chumper/Datatable/Engines/QueryEngine.php
+++ b/src/Chumper/Datatable/Engines/QueryEngine.php
@@ -99,9 +99,9 @@ class QueryEngine extends BaseEngine {
         return $this;
     }
 
-    public function setEmptyAtEnd()
+    public function setEmptyAtEnd($value = true)
     {
-        $this->options['emptyAtEnd'] = true;
+        $this->options['emptyAtEnd'] = $value;
         return $this;
     }
 

--- a/src/Chumper/Datatable/Engines/QueryEngine.php
+++ b/src/Chumper/Datatable/Engines/QueryEngine.php
@@ -362,20 +362,25 @@ class QueryEngine extends BaseEngine {
         //var_dump($this->orderColumn);
         if(!is_null($this->orderColumn))
         {
-            foreach ($this->orderColumn as $ordCol) {
-                if(strrpos($ordCol[1], ':')){
-                    $c = explode(':', $ordCol[1]);
-                    if(isset($c[2]))
-                        $c[1] .= "($c[2])";
-                    $prefix = $this->options['emptyAtEnd'] ? "ISNULL({$c[0]}) asc," : '';
-                    $builder = $builder->orderByRaw($prefix." cast($c[0] as $c[1]) ".$this->orderDirection[$ordCol[0]]);
+            $i = 0;
+            foreach($columns as $col)
+            {
+                if($i === (int) $this->orderColumn[0])
+                {
+                    if(isset($this->orderColumn[1]) && strrpos($this->orderColumn[1], ':')){
+                        $c = explode(':', $this->orderColumn[1]);
+                        if(isset($c[2]))
+                            $c[1] .= "($c[2])";
+                        $builder = $builder->orderByRaw("cast($c[0] as $c[1]) ".$this->orderDirection);
+                    }
+                    else
+                        $builder = $builder->orderBy($col->getName(), $this->orderDirection);
+                    return $builder;
                 }
-                else {
-                    $prefix = $this->options['emptyAtEnd'] ? "ISNULL({$ordCol[1]}) asc," : '';
-                    $builder = $builder->orderByRaw($prefix.' '.$ordCol[1].' '.$this->orderDirection[$ordCol[0]]);
-                }
+                $i++;
             }
         }
         return $builder;
+
     }
 }

--- a/tests/Engines/CollectionEngineTest.php
+++ b/tests/Engines/CollectionEngineTest.php
@@ -101,7 +101,7 @@ class CollectionEngineTest extends TestCase {
         $engine->searchColumns('id');
         $engine->setAliasMapping();
 
-        $should = '{"aaData":[{"id":"eoo"}],"sEcho":0,"iTotalRecords":2,"iTotalDisplayRecords":1}';
+        $should = '{"aaData":[{"id":"eoo"}],"sEcho":0,"iTotalRecords":2,"iTotalDisplayRecords":1,"aaAdditional":null}';
         $actual = $engine->make()->getContent();
 
         $this->assertEquals($should,$actual);

--- a/tests/Engines/QueryEngineTest.php
+++ b/tests/Engines/QueryEngineTest.php
@@ -34,7 +34,7 @@ class QueryEngineTest extends PHPUnit_Framework_TestCase {
 
     public function testOrder()
     {
-        $this->builder->shouldReceive('orderBy')->with('id', BaseEngine::ORDER_ASC);
+        $this->builder->shouldReceive('orderByRaw')->with('id', BaseEngine::ORDER_ASC);
 
         Input::merge(
             array(

--- a/tests/TableTest.php
+++ b/tests/TableTest.php
@@ -1,16 +1,46 @@
 <?php
 
+use Mockery as m;
 use Chumper\Datatable\Table;
 use Illuminate\Support\Facades\Request;
+use Illuminate\Foundation\Testing\TestCase;
 
-class TableTest extends PHPUnit_Framework_TestCase {
+use Illuminate\View\View;
+use Illuminate\Support\Contracts\ArrayableInterface;
+
+
+class TableTest extends TestCase {
 
     /**
      * @var Table
      */
     private $table;
 
-    protected function setUp()
+    public function createApplication()
+    {
+        $this->view = Mockery::mock('ViewMock');
+        Illuminate\Support\Facades\View::swap($this->view);
+
+        $unitTesting = true;
+        $testEnvironment = 'testing';
+
+        $app = new Illuminate\Foundation\Application;
+
+        $env = $app->detectEnvironment(array(
+            'local' => array('homestead'),
+        ));
+
+
+
+        $app->bindInstallPaths(require __DIR__.'/../resources/paths.php');
+
+        $framework = __DIR__ . '/../vendor/laravel/framework/src';
+        require $framework . '/Illuminate/Foundation/start.php';
+
+        return $app;
+    }
+
+    public function setUp()
     {
         parent::setUp();
 
@@ -29,6 +59,7 @@ class TableTest extends PHPUnit_Framework_TestCase {
             )
         );
 
+
         $this->table = new Table();
     }
 
@@ -37,7 +68,7 @@ class TableTest extends PHPUnit_Framework_TestCase {
      */
     public function testSetOptions()
     {
-        $this->table->setOptions('foo','bar');
+        $this->table->setOptions('foo', 'bar');
 
         $this->table->setOptions(array(
             'foo2' => 'bar2',
@@ -63,7 +94,7 @@ class TableTest extends PHPUnit_Framework_TestCase {
         $this->assertArrayHasKey('foo3', $this->table->getCallbacks());
 
         $this->table->setCallbacks('foo', 'bar', 'baz');
-        $this->assertTrue(False);  // should throw exception before here
+        $this->assertTrue(false);  // should throw exception before here
     }
 
     /**
@@ -82,7 +113,7 @@ class TableTest extends PHPUnit_Framework_TestCase {
         $this->assertArrayHasKey('foo3', $this->table->getCustomValues());
 
         $this->table->setCustomValues('foo', 'bar', 'baz');
-        $this->assertTrue(False);  // should throw exception before here
+        $this->assertTrue(false);  // should throw exception before here
     }
 
     public function testAddColumn()
@@ -91,11 +122,11 @@ class TableTest extends PHPUnit_Framework_TestCase {
 
         $this->assertEquals(1, $this->table->countColumns());
 
-        $this->table->addColumn('foo1','foo2');
+        $this->table->addColumn('foo1', 'foo2');
 
         $this->assertEquals(3, $this->table->countColumns());
 
-        $this->table->addColumn(array('foo3','foo4'));
+        $this->table->addColumn(array('foo3', 'foo4'));
 
         $this->assertEquals(5, $this->table->countColumns());
     }
@@ -141,7 +172,7 @@ class TableTest extends PHPUnit_Framework_TestCase {
         );
 
         $this->table->setData($data);
-        $this->assertEquals($data,$this->table->getData());
+        $this->assertEquals($data, $this->table->getData());
 
     }
 
@@ -149,16 +180,17 @@ class TableTest extends PHPUnit_Framework_TestCase {
     {
         $this->table->setUrl('foo/url');
 
-        $this->assertArrayHasKey('bServerSide',$this->table->getOptions());
-        $this->assertArrayHasKey('sAjaxSource',$this->table->getOptions());
+        $this->assertArrayHasKey('bServerSide', $this->table->getOptions());
+        $this->assertArrayHasKey('sAjaxSource', $this->table->getOptions());
 
         $return = $this->table->getOptions();
 
-        $this->assertEquals('foo/url',$return['sAjaxSource']);
+        $this->assertEquals('foo/url', $return['sAjaxSource']);
     }
 
     protected function tearDown()
     {
         Mockery::close();
     }
+
 }


### PR DESCRIPTION
These patches will allow PHPUnit to correctly run all but two unit tests:
* CollectionEngineTest::testOrder
* TableTest::testRender