### PR TITLE
Added and fixed issues to Search and setOrder

### DIFF
--- a/src/Chumper/Datatable/Engines/QueryEngine.php
+++ b/src/Chumper/Datatable/Engines/QueryEngine.php
@@ -169,24 +169,22 @@ class QueryEngine extends BaseEngine {
         $exact = $this->exactWordSearch;
         $builder = $builder->where(function($query) use ($columns, $search, $like, $exact) {
             foreach ($columns as $c) {
-                foreach ($columns as $c) {
-                    //column to search within relationships : relatedModel::column
-                    if(strrpos($c, '::')) {
-                        $c = explode('::', $c);
-                        $query->orWhereHas($c[0], function($q) use($c, $like, $exact, $search){
-                            $q->where($c[1], $like, $exact ? $search : '%' . $search . '%');
-                        });
-                    }
-                    //column to CAST following the pattern column:newType:[maxlength]
-                    elseif(strrpos($c, ':')){
-                        $c = explode(':', $c);
-                        if(isset($c[2]))
-                            $c[1] .= "($c[2])";
-                        $query->orWhereRaw("cast($c[0] as $c[1]) ".$like." ?", array($exact ? "$search" : "%$search%"));
-                    }
-                    else
-                        $query->orWhere($c, $like, $exact ? $search : '%' . $search . '%');
+                //column to search within relationships : relatedModel::column
+                if(strrpos($c, '::')) {
+                    $c = explode('::', $c);
+                    $query->orWhereHas($c[0], function($q) use($c, $like, $exact, $search){
+                        $q->where($c[1], $like, $exact ? $search : '%' . $search . '%');
+                    });
                 }
+                //column to CAST following the pattern column:newType:[maxlength]
+                elseif(strrpos($c, ':')){
+                    $c = explode(':', $c);
+                    if(isset($c[2]))
+                        $c[1] .= "($c[2])";
+                    $query->orWhereRaw("cast($c[0] as $c[1]) ".$like." ?", array($exact ? "$search" : "%$search%"));
+                }
+                else
+                    $query->orWhere($c, $like, $exact ? $search : '%' . $search . '%');
             }
         });
         return $builder;

--- a/src/Chumper/Datatable/Engines/QueryEngine.php
+++ b/src/Chumper/Datatable/Engines/QueryEngine.php
@@ -169,15 +169,24 @@ class QueryEngine extends BaseEngine {
         $exact = $this->exactWordSearch;
         $builder = $builder->where(function($query) use ($columns, $search, $like, $exact) {
             foreach ($columns as $c) {
-                //column to CAST following the pattern column:newType:[maxlength]
-                if(strrpos($c, ':')){
-                    $c = explode(':', $c);
-                    if(isset($c[2]))
-                        $c[1] .= "($c[2])";
-                    $query->orWhereRaw("cast($c[0] as $c[1]) ".$like." ?", array($exact ? "$search" : "%$search%"));
+                foreach ($columns as $c) {
+                    //column to search within relationships : relatedModel::column
+                    if(strrpos($c, '::')) {
+                        $c = explode('::', $c);
+                        $query->orWhereHas($c[0], function($q) use($c, $like, $exact, $search){
+                            $q->where($c[1], $like, $exact ? $search : '%' . $search . '%');
+                        });
+                    }
+                    //column to CAST following the pattern column:newType:[maxlength]
+                    elseif(strrpos($c, ':')){
+                        $c = explode(':', $c);
+                        if(isset($c[2]))
+                            $c[1] .= "($c[2])";
+                        $query->orWhereRaw("cast($c[0] as $c[1]) ".$like." ?", array($exact ? "$search" : "%$search%"));
+                    }
+                    else
+                        $query->orWhere($c, $like, $exact ? $search : '%' . $search . '%');
                 }
-                else
-                    $query->orWhere($c,$like,$exact ? $search : '%'.$search.'%');
             }
         });
         return $builder;

--- a/src/Chumper/Datatable/Table.php
+++ b/src/Chumper/Datatable/Table.php
@@ -169,12 +169,10 @@ class Table {
         $_orders = array();
         foreach ($order as $number => $sort)
         {
-            $_orders[] .= '[ ' . $number . ', "' . $sort . '" ]';
+            $_orders[] = [$number, "' . $sort . '" ];
         }
 
-        $_build = '[' . implode(', ', $_orders) . ']';
-
-        $this->callbacks['aaSorting'] = $_build;
+        $this->callbacks['aaSorting'] = $_orders;
         return $this;
     }
 

--- a/src/Chumper/Datatable/Table.php
+++ b/src/Chumper/Datatable/Table.php
@@ -169,7 +169,7 @@ class Table {
         $_orders = array();
         foreach ($order as $number => $sort)
         {
-            $_orders[] = [$number, "' . $sort . '" ];
+            $_orders[] = [$number, $sort];
         }
 
         $this->callbacks['aaSorting'] = $_orders;


### PR DESCRIPTION
* Added search results from relationships to QueryEngine : 
  * Pass "relationshipModel::column" to apply search
* Fixed issue with Table::setOrder (array was displayed as string)

(This is a new pull request, which replaces #316... The other pull request had lots of commits on there :+1:)