### PR TITLE
Fixed for L5.2 compatibility

### DIFF
--- a/src/Chumper/Datatable/Engines/CollectionEngine.php
+++ b/src/Chumper/Datatable/Engines/CollectionEngine.php
@@ -134,7 +134,7 @@ class CollectionEngine extends BaseEngine {
         $this->doInternalSearch($columns, $searchColumns);
         $this->doInternalOrder();
 
-        return $this->workingCollection->slice($this->skip,$this->limit);
+        return $this->workingCollection->slice($this->skip,$this->limit)->values();
     }
 
     private function doInternalSearch(Collection $columns, array $searchColumns)


### PR DESCRIPTION
L5.2 has some changes in Illuminate\Support\Collection, so chumper/datatables Collection-based table doesn't work as expected. When you have paginated table, it works well on first page (returns array as expected), but if you try to get results on any other page, it returns an object, which can't be shown in table, because table expects array, so you get empty table window.

More information on changes in L5.2 Illuminate\Support\Collection can be found on following links:
- https://github.com/laravel/framework/issues/13692
- https://github.com/laravel/framework/pull/13698