### PR TITLE
Remove the newline character for the table-options

### DIFF
--- a/src/Chumper/Datatable/Table.php
+++ b/src/Chumper/Datatable/Table.php
@@ -336,7 +336,7 @@ class Table {
 				}
 				$first = false;
 			} else {
-				$data .= ",\n";
+				$data .= ",";
 			}
 			if (!is_numeric($k)) {
 				$data .= json_encode($k) . ":";


### PR DESCRIPTION
No need to have a newline for every option-key/value of the table-options ...